### PR TITLE
修复在Android Plugin for Gradle 3.0.0下构建项目失败的问题

### DIFF
--- a/dialog/src/main/res/values/styles.xml
+++ b/dialog/src/main/res/values/styles.xml
@@ -14,13 +14,13 @@
     </style>-->
 
     <style name="mystyle" parent="android:Animation">
-    <item name="@android:windowEnterAnimation">@anim/dialog_enter</item>  //进入时的动画
-    <item name="@android:windowExitAnimation">@anim/dialog_exit</item>    //退出时的动画
+    <item name="android:windowEnterAnimation">@anim/dialog_enter</item>  //进入时的动画
+    <item name="android:windowExitAnimation">@anim/dialog_exit</item>    //退出时的动画
 </style>
 
     <style name="dialog_center" parent="android:Animation">
-        <item name="@android:windowEnterAnimation">@anim/dialog_enter_center</item>  //进入时的动画
-        <item name="@android:windowExitAnimation">@anim/dialog_exit_center</item>    //退出时的动画
+        <item name="android:windowEnterAnimation">@anim/dialog_enter_center</item>  //进入时的动画
+        <item name="android:windowExitAnimation">@anim/dialog_exit_center</item>    //退出时的动画
     </style>
     <style name="notitle" >
         <item name="android:windowNoTitle">true</item>


### PR DESCRIPTION
原因是AAPT2的构建行为发生了改变，可参考官方文档：https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html#aapt2